### PR TITLE
feat(design-system/DT-6): allow generation of both UIKit and SwiftUI font files

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -147,18 +147,28 @@ ios:
 
   # [optional] Parameters for exporting typography
   typography:
-    # [optional] Absolute or relative path to swift file where to export UIKit fonts (UIFont extension).
+    # Choose what font system you want to use SwiftUI or UIKit
+    fontSystem: UIKit
+    # Typography name style: camelCase or snake_case
+    nameStyle: camelCase
+    
+    # Absolute or relative path to swift file where to export UIKit fonts (UIFont extension).
     fontSwift: "./Source/UIComponents/UIFont+extension.swift"
-    # [optional] Absolute or relative path to swift file where to generate TextStyle extensions for each style (TextStyle extension).
-    textStyleSwift: "./Source/UIComponents/TextStyle+extension.swift"
+    # [optional] Absolute or relative path to swift file where to generate LabelStyle extensions for each style (LabelStyle extension).
+    labelStyleSwift: "./Source/UIComponents/LabelStyle+extension.swift"
+    # Should FigmaExport generate UILabel for each text style (font)? E.g. HeaderLabel, BodyLabel, CaptionLabel
+    generateLabels: true
+    # Relative or absolute path to directory where to place UILabel for each text style (font) (Required if generateLabels = true)
+    labelsDirectory: "./Source/UIComponents/"
+    
     # [optional] Absolute or relative path to swift file where to export SwiftUI fonts (Font extension).
     swiftUIFontSwift: "./Source/View/Common/Font+extension.swift"
+    # [optional] Absolute or relative path to swift file where to generate TextStyle extensions for each style (TextStyle extension).
+    textStyleSwift: "./Source/UIComponents/TextStyle+extension.swift"
     # Should FigmaExport generate TextStyles for each text style (font)? E.g. Header, Body, Caption
     generateTextStyles: true
     # Relative or absolute path to directory where to place TextStyles for each text style (font) (Required if generateTextStyles = true)
     textStylesDirectory: "./Source/UIComponents/"
-    # Typography name style: camelCase or snake_case
-    nameStyle: camelCase
 
 # [optional] Android export parameters
 android:

--- a/Examples/Example/Pods/FigmaExport/Release/figma-export.yaml
+++ b/Examples/Example/Pods/FigmaExport/Release/figma-export.yaml
@@ -80,10 +80,10 @@ ios:
     fontSwift: "./Source/UIComponents/UIFont+extension.swift"
     # [optional] Absolute or relative path to swift file where to export SwiftUI fonts (Font extension).
     swiftUIFontSwift: "./Source/View/Common/Font+extension.swift"
-    # Should FigmaExport generate TextStyles for each text style (font)? E.g. Header, Body, Caption
-    generateStyles: true
-    # Relative or absolute path to directory where to place TextStyles for each text style (font) (Required if generateTextStyles = true)
-    textStylesDirectory: "./Source/UIComponents/"
+    # Should FigmaExport generate UILabel for each text style (font)? E.g. HeaderLabel, BodyLabel, CaptionLabel
+    generateLabels: true
+    # Relative or absolute path to directory where to place UILabel for each text style (font) (Requred if generateLabels = true)
+    labelsDirectory: "./Source/UIComponents/"
 
 # [optional] Android export parameters
 android:

--- a/README.md
+++ b/README.md
@@ -203,11 +203,13 @@ If name of an image contains idiom at the end (e.g. ~ipad), it will be exported 
 
 #### Typography
 
-When your execute `figma-export typography` command `figma-export` generates 3 files:
-1. `TextStyle.swift` struct for generating TextStyles for SwiftUI with custom line spacing, kerning (letter spacing) and text case.
-2. `TextStyle+extension.swift` extension including all the custom TextStyles from the Figma file.
-3. `Font+extension` extension for Font that declares your custom fonts.
-4. `UIFont+extension.swift` extension for UIFont that declares your custom fonts. Mainly used to get the default font lineHeight.
+When your execute `figma-export typography` command `figma-export` generates 6 files:
+1. `UIFont+extension.swift` extension for UIFont that declares your custom fonts. Mainly used to get the default font lineHeight.
+2. `Font+extension` extension for Font that declares your custom fonts.
+3. `TextStyle.swift` struct for generating TextStyles for SwiftUI with custom line spacing, kerning (letter spacing) and text case.
+4. `TextStyle+extension.swift` extension including all the custom TextStyles from the Figma file.
+5. `LabelStyle.swift` struct for generating attributes for NSAttributesString with custom lineHeight and tracking (letter spacing).
+6. `Label.swift` file that contains base Label class and class for each text style. E.g. HeaderLabel, BodyLabel, Caption1Label. Specify these classes in xib files on in code.
 
 Example of these files:
 - [./Examples/Example/UIComponents/Source/Typography/TextStyle.swift](./Examples/Example/UIComponents/Source/Typography/TextStyle.swift)

--- a/Sources/FigmaExport/Input/Params.swift
+++ b/Sources/FigmaExport/Input/Params.swift
@@ -93,14 +93,16 @@ struct Params: Decodable {
         }
 
         struct Typography: Decodable {
-			let fontSystem: FontSystem?
-            let fontSwift: URL?
-            let textStyleSwift: URL?
-			let labelStyleSwift: URL?
-            let swiftUIFontSwift: URL?
-            let generateStyles: Bool
-            let stylesDirectory: URL?
+            let fontSystem: FontSystem?
             let nameStyle: NameStyle
+            let fontSwift: URL?
+            let labelStyleSwift: URL?
+            let generateLabels: Bool
+            let labelsDirectory: URL?
+            let swiftUIFontSwift: URL?
+            let textStyleSwift: URL?
+            let generateTextStyles: Bool
+            let textStylesDirectory: URL?
         }
 
         let xcodeprojPath: String

--- a/Sources/FigmaExport/Subcommands/ExportTypography.swift
+++ b/Sources/FigmaExport/Subcommands/ExportTypography.swift
@@ -63,18 +63,25 @@ extension FigmaExportCommand {
                 fontExtensionURL: iosParams.typography?.fontSwift,
                 swiftUIFontExtensionURL: iosParams.typography?.swiftUIFontSwift
             )
-            let styleUrls = XcodeTypographyOutput.StyleURLs(
-                directory: iosParams.typography?.stylesDirectory,
-                extensionsURL: iosParams.typography?.textStyleSwift
+            let labelUrls = XcodeTypographyOutput.LabelURLs(
+                labelsDirectory: iosParams.typography?.labelsDirectory,
+                labelStyleExtensionsURL: iosParams.typography?.labelStyleSwift
+            )
+
+            let textstyleUrls = XcodeTypographyOutput.TextStyleURLs(
+                textStyleDirectory: iosParams.typography?.textStylesDirectory,
+                textStyleExtensionsURL: iosParams.typography?.textStyleSwift
             )
             let urls = XcodeTypographyOutput.URLs(
                 fonts: fontUrls,
-                styles: styleUrls
+                labels: labelUrls,
+                textStyles: textstyleUrls
             )
             return XcodeTypographyOutput(
                 fontSystem: iosParams.typography?.fontSystem,
                 urls: urls,
-                generateStyles: iosParams.typography?.generateStyles,
+                generateLabels: iosParams.typography?.generateLabels,
+                generateTextStyles: iosParams.typography?.generateTextStyles,
                 addObjcAttribute: iosParams.addObjcAttribute,
                 templatesPath: iosParams.templatesPath
             )

--- a/Sources/XcodeExport/Model/XcodeTypographyOutput.swift
+++ b/Sources/XcodeExport/Model/XcodeTypographyOutput.swift
@@ -35,7 +35,8 @@ public enum FontSystem: String, Decodable {
 public struct XcodeTypographyOutput {
     let fontSystem: FontSystem
     let urls: URLs
-    let generateStyles: Bool
+    let generateLabels: Bool
+    let generateTextStyles: Bool
     let addObjcAttribute: Bool
     let templatesPath: URL?
     
@@ -50,43 +51,61 @@ public struct XcodeTypographyOutput {
             self.fontExtensionURL = fontExtensionURL
         }
     }
-    
-    public struct StyleURLs {
-        let directory: URL?
-        let extensionsURL: URL?
+
+    public struct LabelURLs {
+        let labelsDirectory: URL?
+        let labelStyleExtensionsURL: URL?
 
         public init(
-            directory: URL? = nil,
-            extensionsURL: URL? = nil
+            labelsDirectory: URL? = nil,
+            labelStyleExtensionsURL: URL? = nil
         ) {
-            self.directory = directory
-            self.extensionsURL = extensionsURL
+            self.labelsDirectory = labelsDirectory
+            self.labelStyleExtensionsURL = labelStyleExtensionsURL
         }
     }
-    
+
+    public struct TextStyleURLs {
+        let textStyleDirectory: URL?
+        let textStyleExtensionsURL: URL?
+
+        public init(
+            textStyleDirectory: URL? = nil,
+            textStyleExtensionsURL: URL? = nil
+        ) {
+            self.textStyleDirectory = textStyleDirectory
+            self.textStyleExtensionsURL = textStyleExtensionsURL
+        }
+    }
+
     public struct URLs {
         public let fonts: FontURLs
-        public let styles: StyleURLs
+        public let labels: LabelURLs
+        public let textStyles: TextStyleURLs
 
         public init(
             fonts: FontURLs,
-            styles: StyleURLs
+            labels: LabelURLs,
+            textStyles: TextStyleURLs
         ) {
             self.fonts = fonts
-            self.styles = styles
+            self.labels = labels
+            self.textStyles = textStyles
         }
     }
 
     public init(
         fontSystem: FontSystem? = .swiftUI,
         urls: URLs,
-        generateStyles: Bool? = false,
+        generateLabels: Bool? = false,
+        generateTextStyles: Bool? = false,
         addObjcAttribute: Bool? = false,
         templatesPath: URL? = nil
     ) {
         self.fontSystem = fontSystem ?? .swiftUI
         self.urls = urls
-        self.generateStyles = generateStyles ?? false
+        self.generateLabels = generateLabels ?? false
+        self.generateTextStyles = generateTextStyles ?? false
         self.addObjcAttribute = addObjcAttribute ?? false
         self.templatesPath = templatesPath
     }

--- a/Sources/XcodeExport/Resources/LabelStyle+extension.swift.stencil
+++ b/Sources/XcodeExport/Resources/LabelStyle+extension.swift.stencil
@@ -5,7 +5,7 @@ public extension LabelStyle {
     {% for style in styles %}
     static func {{ style.varName }}() -> LabelStyle {
         LabelStyle(
-            font: UIFont.{{ style.varName }}(){% if style.supportsDynamicType %},
+            font: UIFont.{{ style.varName }}{% if style.supportsDynamicType %},
             fontMetrics: UIFontMetrics(forTextStyle: .{{ style.type }}){% endif %}{% if style.lineHeight != 0 %},
             lineHeight: {{ style.lineHeight }}{% endif %}{% if style.tracking != 0 %},
             tracking: {{ style.tracking }}{% endif %}{% if style.textCase != "original" %},

--- a/Tests/XcodeExportTests/XcodeTypographyExporterTests.swift
+++ b/Tests/XcodeExportTests/XcodeTypographyExporterTests.swift
@@ -26,10 +26,13 @@ final class XcodeTypographyExporterTests: XCTestCase {
         let fontUrls = XcodeTypographyOutput.FontURLs(
             fontExtensionURL: URL(string: "~/UIFont+extension.swift")!
         )
-        let styleUrls = XcodeTypographyOutput.StyleURLs()
+        let labelUrls = XcodeTypographyOutput.LabelURLs()
+        let textStyleUrls = XcodeTypographyOutput.TextStyleURLs()
+
         let urls = XcodeTypographyOutput.URLs(
             fonts: fontUrls,
-            styles: styleUrls
+            labels: labelUrls,
+            textStyles: textStyleUrls
         )
         let output = XcodeTypographyOutput(urls: urls)
         let exporter = XcodeTypographyExporter(output: output)
@@ -110,10 +113,13 @@ final class XcodeTypographyExporterTests: XCTestCase {
         let fontUrls = XcodeTypographyOutput.FontURLs(
             fontExtensionURL: URL(string: "~/UIFont+extension.swift")!
         )
-        let styleUrls = XcodeTypographyOutput.StyleURLs()
+        let labelUrls = XcodeTypographyOutput.LabelURLs()
+        let textStyleUrls = XcodeTypographyOutput.TextStyleURLs()
+
         let urls = XcodeTypographyOutput.URLs(
             fonts: fontUrls,
-            styles: styleUrls
+            labels: labelUrls, 
+            textStyles: textStyleUrls
         )
         let output = XcodeTypographyOutput(
             urls: urls,
@@ -197,10 +203,12 @@ final class XcodeTypographyExporterTests: XCTestCase {
         let fontUrls = XcodeTypographyOutput.FontURLs(
             swiftUIFontExtensionURL: URL(string: "~/Font+extension.swift")!
         )
-        let styleUrls = XcodeTypographyOutput.StyleURLs()
+        let labelUrls = XcodeTypographyOutput.LabelURLs()
+        let textStyleUrls = XcodeTypographyOutput.TextStyleURLs()
         let urls = XcodeTypographyOutput.URLs(
             fonts: fontUrls,
-            styles: styleUrls
+            labels: labelUrls,
+            textStyles: textStyleUrls
         )
         let output = XcodeTypographyOutput(urls: urls)
         let exporter = XcodeTypographyExporter(output: output)
@@ -269,17 +277,23 @@ final class XcodeTypographyExporterTests: XCTestCase {
     
     func testExportStyleExtensions() throws {
         let fontUrls = XcodeTypographyOutput.FontURLs()
-        let styleUrls = XcodeTypographyOutput.StyleURLs(
-            directory: URL(string: "~/")!,
-            extensionsURL: URL(string: "~/TextStyle+extension.swift")!
+        let textStyleUrls = XcodeTypographyOutput.TextStyleURLs(
+            textStyleDirectory: URL(string: "~/")!,
+            textStyleExtensionsURL: URL(string: "~/TextStyle+extension.swift")!
+        )
+        let labelUrls = XcodeTypographyOutput.LabelURLs(
+            labelsDirectory: URL(string: "~/")!,
+            labelStyleExtensionsURL: URL(string: "~/LabelStyle+extension.swift")!
         )
         let urls = XcodeTypographyOutput.URLs(
             fonts: fontUrls,
-            styles: styleUrls
+            labels: labelUrls,
+            textStyles: textStyleUrls
         )
         let output = XcodeTypographyOutput(
             urls: urls,
-            generateStyles: true
+            generateLabels: true,
+            generateTextStyles: true
         )
         let exporter = XcodeTypographyExporter(output: output)
         
@@ -521,7 +535,19 @@ final class XcodeTypographyExporterTests: XCTestCase {
         """
                 
         XCTAssertEqual(files.count, 3, "Must be generated 3 files but generated \(files.count)")
-                
+
+        // Label.swift
+        XCTAssertNoDifference(
+            files[0],
+            FileContents(
+                destination: Destination(
+                    directory: URL(string: "~/")!,
+                    file: URL(string: "Label.swift")!
+                ),
+                data: contentsLabel.data(using: .utf8)!
+            )
+        )
+
         // LabelStyle.swift
         XCTAssertNoDifference(
             files[1],
@@ -545,23 +571,50 @@ final class XcodeTypographyExporterTests: XCTestCase {
                 data: styleExtensionContent.data(using: .utf8)!
             )
         )
+
+        // LabelStyle.swift
+        XCTAssertNoDifference(
+            files[1],
+            FileContents(
+                destination: Destination(
+                    directory: URL(string: "~/")!,
+                    file: URL(string: "LabelStyle.swift")!
+                ),
+                data: contentsLabelStyle.data(using: .utf8)!
+            )
+        )
+
+        // LabelStyle+extension.swift
+        XCTAssertNoDifference(
+            files[2],
+            FileContents(
+                destination: Destination(
+                    directory: URL(string: "~/")!,
+                    file: URL(string: "LabelStyle+extension.swift")!
+                ),
+                data: styleExtensionContent.data(using: .utf8)!
+            )
+        )
+        // TODO: test for text styles
     }
     
     func testExportLabel() throws {
         let fontUrls = XcodeTypographyOutput.FontURLs()
-        let styleUrls = XcodeTypographyOutput.StyleURLs(
-            directory: URL(string: "~/")!
+        let labelUrls = XcodeTypographyOutput.LabelURLs(
+            labelsDirectory: URL(string: "~/")!
         )
+        let textStyleUrls = XcodeTypographyOutput.TextStyleURLs()
         let urls = XcodeTypographyOutput.URLs(
             fonts: fontUrls,
-            styles: styleUrls
+            labels: labelUrls,
+            textStyles: textStyleUrls
         )
         let output = XcodeTypographyOutput(
             urls: urls,
-            generateStyles: true
+            generateLabels: true
         )
         let exporter = XcodeTypographyExporter(output: output)
-        
+
         let styles = [
             makeTextStyle(name: "largeTitle", fontName: "PTSans-Bold", fontStyle: .largeTitle, fontSize: 34, lineHeight: nil),
             makeTextStyle(name: "titleSection", fontName: "PTSans-Bold", fontSize: 20, textCase: .uppercased),
@@ -770,7 +823,18 @@ final class XcodeTypographyExporterTests: XCTestCase {
         """
         
         XCTAssertEqual(files.count, 2, "Must be generated 2 files but generated \(files.count)")
-                
+
+        XCTAssertNoDifference(
+            files[0],
+            FileContents(
+                destination: Destination(
+                    directory: URL(string: "~/")!,
+                    file: URL(string: "Label.swift")!
+                ),
+                data: contentsLabel.data(using: .utf8)!
+            )
+        )
+
         XCTAssertNoDifference(
             files[1],
             FileContents(


### PR DESCRIPTION
Making some updates based on my comments in the original [fueled-typography](https://github.com/Fueled/figma-export/pull/1) PR

The main update is to allow generation of both UIKit's `Label.swift`, `LabelStyle.swift`, `LabelStyle+extension.swift` and SwiftUI's `TextStyle.swift`, `TextStyle+extension.swift`.

**Question:** 
- Do we need a `fontSystem` parameter? I don't think it is necessary, since we have to specify the generated file path anyways in the yml if we want to generate certain files , we can simply check whether the file path exists, for the same reason, we could also remove the `generateLabels` and `generateStyles` params
- Do we want to include the example folder in our repo at all? Since there's a lot inside `Example` to maintain every time we make updates

**TODO:**
- fix tests
- update `Example` dir to reflect our changes or remove it
- potentially remove `fontSystem` param
